### PR TITLE
Bash timeout

### DIFF
--- a/pipelines/pipeline/task.py
+++ b/pipelines/pipeline/task.py
@@ -32,9 +32,10 @@ class Task(object):
 
 
 class TaskResult(dict):
-    def __init__(self, status, message=''):
+    def __init__(self, status, message='', data={}):
         self['status'] = status
         self['message'] = message
+        self['data'] = data
 
     @property
     def status(self):
@@ -44,6 +45,9 @@ class TaskResult(dict):
     def message(self):
         return self.get('message')
 
+    @property
+    def data(self):
+        return self.get('data')
 
     def is_successful(self):
         return self.status == EXECUTION_SUCCESSFUL

--- a/pipelines/plugins/bash_executor.py
+++ b/pipelines/plugins/bash_executor.py
@@ -8,8 +8,6 @@ from sh import bash
 
 log = logging.getLogger('pipelines')
 TIMEOUT = 60*60  # Timeout to 1h
-f2455441c363126a31043a5057e8c0122fdb0bd3
-8ca487aae1ed40ac0fb8a67e79678d6d59ba35e9
 
 class BashExecuteError(PluginError):
     def __init__(self, msg, code):


### PR DESCRIPTION
Features added:
- Set default timeout to 1h for bash tasks
- Improve printing task result in log, for example when timed out:

> 09:59:22 Task finished, name: Task-2, status: 1, msg: Bash task failed: Task Timed Out

