### PR TITLE
Support variable passing for python and bash actions.

### DIFF
--- a/pipelines/pipeline/task.py
+++ b/pipelines/pipeline/task.py
@@ -41,10 +41,11 @@ class Task(object):
 
 
 class TaskResult(dict):
-    def __init__(self, status, message='', data={}):
+    def __init__(self, status, message='', data={}, return_obj={}):
         self['status'] = status
         self['message'] = message
         self['data'] = data
+        self['return_obj'] = return_obj
 
     @property
     def status(self):
@@ -57,6 +58,10 @@ class TaskResult(dict):
     @property
     def data(self):
         return self.get('data')
+
+    @property
+    def return_obj(self):
+        return self.get('return_obj')
 
     def is_successful(self):
         return self.status == EXECUTION_SUCCESSFUL

--- a/pipelines/plugins/python_executor.py
+++ b/pipelines/plugins/python_executor.py
@@ -64,15 +64,16 @@ class PythonExecutor(BashExecutor):
         if self.dry_run:
             return TaskResult(EXECUTION_SUCCESSFUL)
 
+        return_obj=None
         try:
-            stdout = self._run_bash(bash_input)
+            stdout, return_obj = self._run_bash(bash_input)
             status = EXECUTION_SUCCESSFUL
         except BashExecuteError as e:
             status = EXECUTION_FAILED
             stdout = e.data.get('stdout')
         print 'Finished, stdout: %s' % (stdout)
 
-        return TaskResult(status, 'Execution finished', data={'output': stdout})
+        return TaskResult(status, 'Execution finished', data={'output': stdout}, return_obj=return_obj)
 
 
 

--- a/test/pipelines/test_pipelines.py
+++ b/test/pipelines/test_pipelines.py
@@ -60,6 +60,39 @@ class TestPipelines(TestCase):
         self.assertEqual(res['results'][0].status, EXECUTION_FAILED)
         self.assertEqual(len(res['results']), 1)
 
+    def test_variable_passing(self):
+        pipeline_def = {
+            'actions': [
+            'echo \'{"test22": 1}\'',
+            'echo "{{ prev_result.return_obj.test22 }}"'
+            ],
+        }
+        pipeline = Pipeline.form_dict(pipeline_def)
+        res = pipeline.run()
+
+        self.assertEqual(res['status'], PIPELINE_STATUS_OK)
+        self.assertEqual(res['results'][1].data['output'].strip(), "1")
+
+    def test_variable_passing_python(self):
+        pipeline_def = {
+            'actions': [
+            {
+                'type': 'python',
+                'script': '''
+import json
+a = {'testpy': 'tdd', 'array': [1,2,3]}
+print json.dumps(a)
+'''
+            },
+            'echo "{{ prev_result.return_obj.testpy }}"'
+            ],
+        }
+        pipeline = Pipeline.form_dict(pipeline_def)
+        res = pipeline.run()
+
+        self.assertEqual(res['status'], PIPELINE_STATUS_OK)
+        self.assertEqual(res['results'][1].data['output'].strip(), "tdd")
+
     def test_templating(self):
         vars = {
             'vars': {

--- a/test/plugins/test_bash.py
+++ b/test/plugins/test_bash.py
@@ -31,17 +31,6 @@ class TestPythonExecutor(TestCase):
     #
     #
     #
-    # def test_basic_script(self):
-    #     print 'Running test_basic_script'
-    #     executor = BashExecutor()
-    #     args = {
-    #         'cmd': 'echo "test"'
-    #     }
-    #     res = executor.execute(args)
-    #     self.assertIsInstance(res, TaskResult)
-    #     self.assertEqual(res.status, EXECUTION_SUCCESSFUL)
-    #     self.assertEqual(res.data['output'].strip(), 'test')
-    #     self.assertEqual(res.message.strip(), 'Bash task finished')
     #
     #
     # def test_timeout_script_pass(self):
@@ -79,6 +68,60 @@ class TestPythonExecutor(TestCase):
     #     pipeline = Pipeline.form_dict(pipeline_def)
     #     res = pipeline.run()
     #     self.assertEqual(res['status'], PIPELINE_STATUS_OK)
+    def test_basic_script(self):
+        print 'Running test_basic_script'
+        executor = BashExecutor()
+        args = {
+            'cmd': 'echo "test"'
+        }
+        res = executor.execute(args)
+        self.assertIsInstance(res, TaskResult)
+        self.assertEqual(res.status, EXECUTION_SUCCESSFUL)
+        self.assertEqual(res.data['output'].strip(), 'test')
+        self.assertEqual(res.message.strip(), 'Bash task finished')
+
+    def test_return_obj(self):
+        print 'Testing return object parsing'
+        executor = BashExecutor()
+        args = {
+            'cmd': 'echo \'{"test": 1}\''
+        }
+        res = executor.execute(args)
+        self.assertIsInstance(res, TaskResult)
+        self.assertEqual(res.status, EXECUTION_SUCCESSFUL)
+        self.assertEqual(res.data['output'].strip(), '{"test": 1}')
+        self.assertEqual(res.return_obj, {"test": 1})
+
+    def test_return_obj_empty_rows(self):
+        print 'Testing return object parsing'
+        executor = BashExecutor()
+        args = {
+            'cmd': 'echo \'{"otest": 1}\n\''
+        }
+        res = executor.execute(args)
+        self.assertEqual(res.return_obj, {"otest": 1})
+
+    def test_return_obj_nojson(self):
+        print 'Testing return object parsing'
+        executor = BashExecutor()
+        args = {
+            'cmd': 'echo \'abba\n"test": 1}\n\''
+        }
+        res = executor.execute(args)
+        self.assertIsNone(res.return_obj)
+
+    # def test_utf_script(self):
+    #     print 'Running test_basic_script'
+    #     executor = BashExecutor()
+    #     args = {
+    #         'cmd': u'echo "test\u4e2dtest"'
+    #     }
+    #     res = executor.execute(args)
+    #     self.assertIsInstance(res, TaskResult)
+    #     self.assertEqual(res.status, EXECUTION_SUCCESSFUL)
+    #     self.assertEqual(res.data['output'].strip(), u'test\u4e2dtest')
+    #     self.assertEqual(res.message.strip(), 'Bash task finished')
+
 
     def test_timeout_in_pipeline_def_timeouts(self):
         pipeline_def = {


### PR DESCRIPTION
This features attempts to parse the last non-empty line of bash/python action output as JSON and attach that as `return_obj` into the TaskResult object so that is accessible by following actions. 

Check the new tests in test_pipelines.py to understand how it works.