### PR TITLE
Add ability to mention user/channel in slack msg

### DIFF
--- a/pipelines/plugins/slack_executor.py
+++ b/pipelines/plugins/slack_executor.py
@@ -32,6 +32,7 @@ class SlackExecutor(BaseExecutorPlugin):
 
         payload = {
             'username': 'Pipelines',
+            'link_names': 1,
             'text': message
         }
 


### PR DESCRIPTION
I want to mention someone explicitly when some task finished in pipelines.

This PR adjusted the parameters sending to slack according to https://api.slack.com/docs/message-formatting