### PR TITLE
Add the default vaule  for start_time field when fetch the old runs

### DIFF
--- a/pipelines/api/server.py
+++ b/pipelines/api/server.py
@@ -311,7 +311,7 @@ def _fetch_runs(path, run_ids):
             log.debug('Run status file doesn\'t exist: %s' % run_status_path)
 
         ret.append(item)
-    ret.sort(key=lambda run: run.get('start_time'), reverse=True)
+    ret.sort(key=lambda run: run.get('start_time', ''), reverse=True)
     return ret
 
 
@@ -451,9 +451,9 @@ def _hide_pw(conf_dict):
 def main(config):
     conf_logging()
     app = make_app(
-        cookie_secret=config.get('cookie_secret'), 
-        workspace=config.get('workspace', 'fixtures/workspace'), 
-        title=config.get('title'), 
+        cookie_secret=config.get('cookie_secret'),
+        workspace=config.get('workspace', 'fixtures/workspace'),
+        title=config.get('title'),
         auth=config.get('auth')
     )
     app.listen(


### PR DESCRIPTION
it's possible that there is no status.json file for a task run, it may fail
before generate status json for some reasons.

in that case, ret.sort() will try to use < to compare the  NonType and str, it's
OK in Python 2 but doesn't work in Python 3:

TypeError: '<' not supported between instances of 'NoneType' and 'str'