### PR TITLE
refactor ghauth handler, get rid of callback style codes

### DIFF
--- a/For-Developers.md
+++ b/For-Developers.md
@@ -19,7 +19,7 @@ make install
 python3 -m venv .venv
 .venv/bin/pip install -U pip
 .venv/bin/pip install -U pipenv
-.venv/bin/pipenv install
+.venv/bin/pipenv install -d
 ```
 
 run API server.

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,12 @@ ${VENV}:
 install: ${VENV}
 	${VENV}/bin/pip install -U pip
 	${VENV}/bin/pip install -U pipenv
-	${VENV}/bin/pipenv install
+	${VENV}/bin/pipenv install -d
 
 run:
-	${VENV}/bin/python -m pipelines ${API_SERVER_ARGS}
+	PROXY_HOST=${PROXY_HOST} PROXY_PORT=${PROXY_PORT} \
+		GH_OAUTH_KEY=${GH_OAUTH_KEY} GH_OAUTH_SECRET=${GH_OAUTH_SECRET} \
+		${VENV}/bin/python -m pipelines ${API_SERVER_ARGS}
 
 test:
 	# PYTHONPATH=./pipelines $(NOSETESTS) -d -v -w test/*

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ filelock = "==3.4.0"
 requests = "==2.26.0"
 schema = "==0.7.5"
 sh = "==1.14.2"
-tornado = "==5.1.1"
+tornado = "==6.1"
 Jinja2 = "==3.0.3"
 PyYAML = "==6.0"
 
@@ -24,6 +24,7 @@ coverage = "*"
 autopep8 = "*"
 pipenv-setup = "*"
 pylint = "*"
+pycurl = "*"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "eb585a5619c781783ff8188d3566917b08a20131df603796f18a20acea1c04cc"
+            "sha256": "ff93e6e268797eeecfc48d803cccb1f05619a28de29ca311898a12a2988b5ff4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
-                "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.5.18.1"
+            "version": "==2022.6.15"
         },
         "charset-normalizer": {
             "hashes": [
@@ -190,16 +190,50 @@
         },
         "tornado": {
             "hashes": [
-                "sha256:0662d28b1ca9f67108c7e3b77afabfb9c7e87bde174fbda78186ecedc2499a9d",
-                "sha256:4e5158d97583502a7e2739951553cbd88a72076f152b4b11b64b9a10c4c49409",
-                "sha256:732e836008c708de2e89a31cb2fa6c0e5a70cb60492bee6f1ea1047500feaf7f",
-                "sha256:8154ec22c450df4e06b35f131adc4f2f3a12ec85981a203301d310abf580500f",
-                "sha256:8e9d728c4579682e837c92fdd98036bd5cdefa1da2aaf6acf26947e6dd0c01c5",
-                "sha256:d4b3e5329f572f055b587efc57d29bd051589fb5a43ec8898c77a47ec2fa2bbb",
-                "sha256:e5f2585afccbff22390cddac29849df463b252b711aa2ce7c5f3f342a5b3b444"
+                "sha256:0a00ff4561e2929a2c37ce706cb8233b7907e0cdc22eab98888aca5dd3775feb",
+                "sha256:0d321a39c36e5f2c4ff12b4ed58d41390460f798422c4504e09eb5678e09998c",
+                "sha256:1e8225a1070cd8eec59a996c43229fe8f95689cb16e552d130b9793cb570a288",
+                "sha256:20241b3cb4f425e971cb0a8e4ffc9b0a861530ae3c52f2b0434e6c1b57e9fd95",
+                "sha256:25ad220258349a12ae87ede08a7b04aca51237721f63b1808d39bdb4b2164558",
+                "sha256:33892118b165401f291070100d6d09359ca74addda679b60390b09f8ef325ffe",
+                "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791",
+                "sha256:3447475585bae2e77ecb832fc0300c3695516a47d46cefa0528181a34c5b9d3d",
+                "sha256:34ca2dac9e4d7afb0bed4677512e36a52f09caa6fded70b4e3e1c89dbd92c326",
+                "sha256:3e63498f680547ed24d2c71e6497f24bca791aca2fe116dbc2bd0ac7f191691b",
+                "sha256:548430be2740e327b3fe0201abe471f314741efcb0067ec4f2d7dcfb4825f3e4",
+                "sha256:6196a5c39286cc37c024cd78834fb9345e464525d8991c21e908cc046d1cc02c",
+                "sha256:61b32d06ae8a036a6607805e6720ef00a3c98207038444ba7fd3d169cd998910",
+                "sha256:6286efab1ed6e74b7028327365cf7346b1d777d63ab30e21a0f4d5b275fc17d5",
+                "sha256:65d98939f1a2e74b58839f8c4dab3b6b3c1ce84972ae712be02845e65391ac7c",
+                "sha256:66324e4e1beede9ac79e60f88de548da58b1f8ab4b2f1354d8375774f997e6c0",
+                "sha256:6c77c9937962577a6a76917845d06af6ab9197702a42e1346d8ae2e76b5e3675",
+                "sha256:70dec29e8ac485dbf57481baee40781c63e381bebea080991893cd297742b8fd",
+                "sha256:7250a3fa399f08ec9cb3f7b1b987955d17e044f1ade821b32e5f435130250d7f",
+                "sha256:748290bf9112b581c525e6e6d3820621ff020ed95af6f17fedef416b27ed564c",
+                "sha256:7da13da6f985aab7f6f28debab00c67ff9cbacd588e8477034c0652ac141feea",
+                "sha256:8f959b26f2634a091bb42241c3ed8d3cedb506e7c27b8dd5c7b9f745318ddbb6",
+                "sha256:9de9e5188a782be6b1ce866e8a51bc76a0fbaa0e16613823fc38e4fc2556ad05",
+                "sha256:a48900ecea1cbb71b8c71c620dee15b62f85f7c14189bdeee54966fbd9a0c5bd",
+                "sha256:b87936fd2c317b6ee08a5741ea06b9d11a6074ef4cc42e031bc6403f82a32575",
+                "sha256:c77da1263aa361938476f04c4b6c8916001b90b2c2fdd92d8d535e1af48fba5a",
+                "sha256:cb5ec8eead331e3bb4ce8066cf06d2dfef1bfb1b2a73082dfe8a161301b76e37",
+                "sha256:cc0ee35043162abbf717b7df924597ade8e5395e7b66d18270116f8745ceb795",
+                "sha256:d14d30e7f46a0476efb0deb5b61343b1526f73ebb5ed84f23dc794bdb88f9d9f",
+                "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32",
+                "sha256:d3d20ea5782ba63ed13bc2b8c291a053c8d807a8fa927d941bd718468f7b950c",
+                "sha256:d3f7594930c423fd9f5d1a76bee85a2c36fd8b4b16921cae7e965f22575e9c01",
+                "sha256:dcef026f608f678c118779cd6591c8af6e9b4155c44e0d1bc0c87c036fb8c8c4",
+                "sha256:e0791ac58d91ac58f694d8d2957884df8e4e2f6687cdf367ef7eb7497f79eaa2",
+                "sha256:e385b637ac3acaae8022e7e47dfa7b83d3620e432e3ecb9a3f7f58f150e50921",
+                "sha256:e519d64089b0876c7b467274468709dadf11e41d65f63bba207e04217f47c085",
+                "sha256:e7229e60ac41a1202444497ddde70a48d33909e484f96eb0da9baf8dc68541df",
+                "sha256:ed3ad863b1b40cd1d4bd21e7498329ccaece75db5a5bf58cd3c9f130843e7102",
+                "sha256:f0ba29bafd8e7e22920567ce0d232c26d4d47c8b5cf4ed7b562b5db39fa199c5",
+                "sha256:fa2ba70284fa42c2a5ecb35e322e68823288a4251f9ba9cc77be04ae15eada68",
+                "sha256:fba85b6cd9c39be262fcd23865652920832b61583de2a2ca907dbd8e8a8c81e5"
             ],
             "index": "pypi",
-            "version": "==5.1.1"
+            "version": "==6.1"
         },
         "urllib3": {
             "hashes": [
@@ -213,11 +247,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:14ffbb4f6aa2cf474a0834014005487f7ecd8924996083ab411e7fa0b508ce0b",
-                "sha256:f4e4ec5294c4b07ac38bab9ca5ddd3914d4bf46f9006eb5c0ae755755061044e"
+                "sha256:4f933d0bf5e408b03a6feb5d23793740c27e07340605f236496cd6ce552043d6",
+                "sha256:ba33a82a9a9c06a5ceed98180c5aab16e29c285b828d94696bf32d6015ea82a9"
             ],
             "markers": "python_full_version >= '3.6.2'",
-            "version": "==2.11.5"
+            "version": "==2.11.6"
         },
         "attrs": {
             "hashes": [
@@ -250,11 +284,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
-                "sha256:f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a"
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.5.18.1"
+            "version": "==2022.6.15"
         },
         "chardet": {
             "hashes": [
@@ -274,11 +308,11 @@
         },
         "colorama": {
             "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
+                "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+                "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.4.4"
+            "version": "==0.4.5"
         },
         "coverage": {
             "hashes": [
@@ -513,6 +547,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.8.0"
         },
+        "pycurl": {
+            "hashes": [
+                "sha256:a863ad18ff478f5545924057887cdae422e1b2746e41674615f687498ea5b88a"
+            ],
+            "index": "pypi",
+            "version": "==7.45.1"
+        },
         "pyflakes": {
             "hashes": [
                 "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
@@ -523,11 +564,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:10d291ea5133645f73fc1b51ca137ad6531223c1461a5632a1db029a9bc033b5",
-                "sha256:ef64ce5d4c17b8906caeaf2c2914ef3036a3a1b7f4a86f5fbf6caff9067c5f63"
+                "sha256:4e1378f815c63e7e44590d0d339ed6435f5281d0a0cc357d29a86ea0365ef868",
+                "sha256:6757a027e15816be23625b079ebc45464e4c9d9dde0c826d18beee53fe22a2e7"
             ],
             "index": "pypi",
-            "version": "==2.14.0"
+            "version": "==2.14.3"
         },
         "pyparsing": {
             "hashes": [
@@ -563,11 +604,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:68e45d17c9281ba25dc0104eadd2647172b3472d9e01f911efa57965e8d51a36",
-                "sha256:a43bdedf853c670e5fed28e5623403bad2f73cf02f9a2774e91def6bda8265a7"
+                "sha256:990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741",
+                "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==62.3.2"
+            "version": "==62.6.0"
         },
         "six": {
             "hashes": [

--- a/pipelines/__init__.py
+++ b/pipelines/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.15'
+__version__ = '0.2.0a1'
 __author__ = 'Wiredcraft'
 
 

--- a/pipelines/api/ghauth.py
+++ b/pipelines/api/ghauth.py
@@ -1,47 +1,31 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
-import os
 import functools
 import json
-from urllib.parse import urlencode
 import logging
-import tornado
+import os
+from urllib.parse import urlencode
+
 import requests
-from tornado.concurrent import return_future
-from tornado.web import RequestHandler
-from tornado.auth import _auth_return_future, AuthError
-from tornado import httpclient
+import tornado
+from tornado import escape, httpclient
+from tornado.auth import AuthError
 from tornado.httputil import url_concat
-from tornado import escape
+from tornado.web import RequestHandler
+
 
 log = logging.getLogger('pipelines')
 
-
 class GithubOAuth2Mixin(object):
+    """
+    see
+    https://docs.github.com/en/developers/apps/building-oauth-apps/authorizing-oauth-apps#web-application-flow
+    """
     _OAUTH_AUTHORIZE_URL = "https://github.com/login/oauth/authorize"
     _OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
     _OAUTH_USER_BASE_URL = "https://api.github.com"
     _OAUTH_SETTINGS_KEY = "github_oauth"
 
-    @return_future
-    def authorize_redirect(self,
-                           scopes=None,
-                           response_type="code",
-                           callback=None,
-                           **kwargs):
-        args = {
-            "client_id": self.gh_settings[self._OAUTH_SETTINGS_KEY]["key"],
-            "response_type": response_type
-        }
-        if kwargs:
-            args.update(kwargs)
-        if scopes:
-            args["scope"] = ",".join(scopes)
-        self.redirect(url_concat(self._OAUTH_AUTHORIZE_URL, args))
-        callback()
-
-    # Copyed from above
-    def get_auth_url(self, scopes=None):
+    def get_auth_url(self, scopes: list[str] = None):
         args = {
             "client_id": self.gh_settings[self._OAUTH_SETTINGS_KEY]["key"],
             "response_type": 'code'
@@ -50,9 +34,10 @@ class GithubOAuth2Mixin(object):
             args["scope"] = ",".join(scopes)
         return url_concat(self._OAUTH_AUTHORIZE_URL, args)
 
-    @_auth_return_future
-    def get_authenticated_user(self, code, callback):
+    @tornado.gen.coroutine
+    def get_authenticated_user(self, code):
         """Handles the login for the Github user, returning a user object.
+
         Example usage::
             class GithubOAuth2LoginHandler(tornado.web.RequestHandler,
                                            GithubOAuth2Mixin):
@@ -62,119 +47,115 @@ class GithubOAuth2Mixin(object):
                         user = yield self.get_authenticated_user(code=self.get_argument("code"))
                         # Save the user with e.g. set_secure_cookie
                     else:
-                        yield self.authorize_redirect(scope=["user:email"])
+                        return self.redirect(self.get_auth_url(scope=["user:email"]))
         """
         http = self.get_auth_http_client()
         body = urlencode({
-            "client_id":
-            self.gh_settings[self._OAUTH_SETTINGS_KEY]["key"],
-            "client_secret":
-            self.gh_settings[self._OAUTH_SETTINGS_KEY]["secret"],
-            "code":
-            code
+            "client_id": self.gh_settings[self._OAUTH_SETTINGS_KEY]["key"],
+            "client_secret": self.gh_settings[self._OAUTH_SETTINGS_KEY]["secret"],
+            "code": code
         })
 
-        http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
-                   functools.partial(self._on_access_token, callback),
-                   method="POST",
-                   headers={
-                       "Content-Type": "application/x-www-form-urlencoded",
-                       "Accept": "application/json"
-                   },
-                   body=body)
-
-    def _on_access_token(self, future, response):
-        """Callback function for the exchange to the access token."""
-        if response.error:
-            future.set_exception(
-                AuthError("Github auth error: %s" % str(response)))
-            return
-        args = escape.json_decode(escape.native_str(response.body))
+        # retrieve access token
+        resp = yield http.fetch(
+            self._OAUTH_ACCESS_TOKEN_URL,
+            method="POST",
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+            },
+            body=body
+        )
+        if resp.error:
+            raise AuthError("Github auth error: %s" % str(resp))
+        args = escape.json_decode(escape.native_str(resp.body))
         access_token = args.get("access_token", None)
         if not access_token:
-            future.set_result(None)
+            log.warn("no access_token in token request")
+            return None
+
+        # retrieve user info
+        user = yield self.github_request(
+            path="/user",
+            access_token=access_token
+        )
+        user['access_token'] = access_token
+
         scopes = args["scope"].split(",")
         has_user_email_scope = scopes.count("user:email") > 0
-        self.github_request(path="/user",
-                            callback=functools.partial(self._on_get_user_info,
-                                                       future, access_token,
-                                                       has_user_email_scope),
-                            access_token=access_token)
-
-    def _on_get_user_info(self, future, access_token, has_user_email_scope,
-                          user):
-        if user is None:
-            future.set_result(None)
-            return
-
-        user.update({"access_token": access_token})
         if not has_user_email_scope:
-            return future.set_result(user)
-        self.github_request(path="/user/emails",
-                            callback=functools.partial(self._on_get_user_email,
-                                                       future, user),
-                            access_token=access_token)
+            return user
 
-    @staticmethod
-    def _on_get_user_email(future, user, emails):
-        user.update({"private_emails": emails})
-        future.set_result(user)
+        # retrieve email info
+        emails = yield self.github_request(
+            path="/user/emails",
+            access_token=access_token
+        )
+        user["private_emails"] = emails
+        return user
 
-    @_auth_return_future
-    def github_request(self,
-                       path,
-                       callback,
-                       access_token=None,
-                       post_args=None,
-                       **args):
+    @tornado.gen.coroutine
+    def github_request(self, path, access_token=None, post_args=None, **args):
         url = self._OAUTH_USER_BASE_URL + path
         all_args = {}
         if access_token:
             all_args.update(args)
         if all_args:
             url += "?" + urlencode(all_args)
-        callback = functools.partial(self._on_github_request, callback)
+
         http = self.get_auth_http_client()
+
         ua = "tornado"
         if post_args is not None:
-            http.fetch(url,
-                       method="POST",
-                       body=urlencode(post_args),
-                       callback=callback,
-                       user_agent=ua,
-                       headers={
-                           "Content-Type": "application/x-www-form-urlencoded",
-                           "Accept": "application/json"
-                       },
-                       auth_mode='basic',
-                       auth_username='_',
-                       auth_password=access_token)
+            resp = yield http.fetch(
+                url, method="POST", body=urlencode(post_args),
+                user_agent=ua,
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
+                auth_mode='basic', auth_username='_', auth_password=access_token)
         else:
-            http.fetch(url,
-                       method="GET",
-                       callback=callback,
-                       user_agent=ua,
-                       headers={"Accept": "application/json"},
-                       auth_mode='basic',
-                       auth_username='_',
-                       auth_password=access_token)
+            resp = yield http.fetch(
+                url, method="GET", user_agent=ua,
+                headers={"Accept": "application/json"}, auth_mode='basic',
+                auth_username='_', auth_password=access_token)
 
-    @staticmethod
-    def _on_github_request(future, response):
-        if response.error:
-            future.set_exception(
-                AuthError("Error response %s fetching %s" %
-                          (response.error, response.request.url)))
-            return
+        if resp.error:
+            raise AuthError("Error response %s fetching %s" %
+                            (response.error, response.request.url))
 
-        future.set_result(escape.json_decode(response.body))
+        return escape.json_decode(resp.body)
 
     @staticmethod
     def get_auth_http_client():
+        impl = 'tornado.simple_httpclient.SimpleAsyncHTTPClient'
+        # debug support
+        proxy_host = os.environ.get("PROXY_HOST")
+        proxy_port = os.environ.get("PROXY_PORT")
+        defaults = {
+            'user_agent': 'tornado',
+        }
+        if proxy_host and proxy_port:
+            log.debug('>> enable proxy support for tornado.httpclient')
+            log.debug('>> proxy: %s:%s', proxy_host, proxy_port)
+            # as for torado 6.0, proxy is only supported in
+            # curl_httpclient, need to install pycurl
+            defaults.update({
+                'proxy_host': proxy_host,
+                'proxy_port': int(proxy_port),
+            })
+            impl = 'tornado.curl_httpclient.CurlAsyncHTTPClient'
+
+        httpclient.AsyncHTTPClient.configure(
+            impl=impl,
+            defaults=defaults)
+
         return httpclient.AsyncHTTPClient()
 
 
-class GithubOAuth2LoginHandler(RequestHandler, GithubOAuth2Mixin):
+class GithubOAuth2LoginHandler(RequestHandler,
+                               GithubOAuth2Mixin):
 
     gh_settings = {
         'github_oauth': {
@@ -191,12 +172,10 @@ class GithubOAuth2LoginHandler(RequestHandler, GithubOAuth2Mixin):
     @tornado.gen.coroutine
     def get(self):
         if self.get_argument('code', False):
-
-            def cb(*args):
-                print('Callback: %s' % args)
-
+            code = self.get_argument('code')
             user = yield self.get_authenticated_user(
-                code=self.get_argument('code'), callback=cb)
+                code=code,
+            )
 
             # r = requests.get('https://api.github.com/user/teams?access_token=%s' % user['access_token'])
 
@@ -211,8 +190,8 @@ class GithubOAuth2LoginHandler(RequestHandler, GithubOAuth2Mixin):
                 self.redirect('/login')
                 return
 
-            r = requests.get('https://api.github.com/user/teams',
-                             auth=('_', user['access_token']))
+            r = requests.get('https://api.github.com/user/teams', auth=('_', user['access_token']))
+
 
             allowed_teams = self.settings['auth'].get('teams', [])
             allowed_teams_set = set()
@@ -223,7 +202,7 @@ class GithubOAuth2LoginHandler(RequestHandler, GithubOAuth2Mixin):
 
             user_teams_set = set()
             for x in teams:
-                o = x.get('organization', {}).get('login', '').lower()
+                o = x.get('organization',{}).get('login', '').lower()
                 t = x.get('slug', '').lower()
                 if not o or not t:
                     continue
@@ -233,17 +212,15 @@ class GithubOAuth2LoginHandler(RequestHandler, GithubOAuth2Mixin):
             intersection = allowed_teams_set.intersection(user_teams_set)
             log.debug('intersection: %s' % intersection)
             if len(intersection) > 0:
-                log.debug('Allowed access to github user for team %s' %
-                          (intersection))
-                user['username'] = username
-                cookie = json.dumps(user, separators=(',', ':'))
-                self.set_secure_cookie('user', cookie)
+                    log.debug('Allowed access to github user for team %s' % (intersection))
+                    user['username'] = username
+                    cookie = json.dumps(user, separators=(',',   ':'))
+                    self.set_secure_cookie('user', cookie)
             else:
-                log.debug('Access not allowed to user. User teams:  %s' % ([
-                    '%s/%s' %
-                    (t.get('organization', {}).get('login'), t.get('slug'))
-                    for t in teams
-                ]))
+                log.debug('Access not allowed to user. User teams:  %s' % (
+                    ['%s/%s' % (t.get('organization', {}).get('login'), t.get('slug')) for t in teams])
+                )
+
 
             self.redirect(self.get_query_argument("next", "/"))
         else:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         ],
     },
     install_requires=[
-        "certifi==2022.5.18.1; python_version >= '3.6'",
+        "certifi==2022.6.15; python_version >= '3.6'",
         "charset-normalizer==2.0.12; python_version >= '3'",
         "contextlib2==21.6.0; python_version >= '3.6'",
         'docopt==0.6.2',
@@ -56,7 +56,7 @@ setup(
         'requests==2.26.0',
         'schema==0.7.5',
         'sh==1.14.2',
-        'tornado==5.1.1',
+        'tornado==6.1',
         "urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'"],
     dependency_links=[],
 )


### PR DESCRIPTION
- remove `return_future` and `_auth_return_future` as they are removed in tornado 6.x
- refactor GithubOAuth2Mixin with `tornado.gen.coroutine`
- upgrade tornado to 6.1
- support `PROXY_HOST` and `PROXY_PORT` in ghauth handler
- add pycurl to dev-dependencies because proxy is only supported
  in `tornado.curl_httpclient.CurlAsyncHTTPClient`

fixes #128 