### PR TITLE
limit run history

### DIFF
--- a/pipelines/cli.py
+++ b/pipelines/cli.py
@@ -2,7 +2,7 @@
 '''
 Usage:
     pipelines (--version|--help)
-    pipelines server --workspace=<workspace> [--title=<title>] [--cookie-secret=<cookie-secret>] [--host=<host>] [--port=<port>] [--username=<username>] [--password=<password>] [--ask-password] [--github-auth=<Org/Team>] [--debug]
+    pipelines server --workspace=<workspace> [--title=<title>] [--cookie-secret=<cookie-secret>] [--host=<host>] [--port=<port>] [--username=<username>] [--password=<password>] [--ask-password] [--github-auth=<Org/Team>] [--debug] [--history-limit=<history-limit>]
 
 Options:
     --host=<host>                       Bind address [default: 127.0.0.1]
@@ -15,6 +15,7 @@ Options:
     --workspace=<workspace>             Location of the pipelines and runs [default: /var/lib/pipelines/workspace]
     --title=<title>                     Title on tab
     --debug                             Set log level to debug
+    --history-limit=<history-limit>     Limit run history loading for pipelines
 
 Help:
     pipelines server            Starts pipelines' server (API + UI)
@@ -102,6 +103,7 @@ def main():
             options['auth'] = ('static', username, password)
 
         options['debug'] = args.get('--debug')
+        options['history_limit'] = int(args.get('--history-limit') or 30)
         try:
             server.main(options)
         except KeyboardInterrupt:


### PR DESCRIPTION
mitigation for #133.

add `--history-limit` flag for limiting loading history runs of pipelines. note that limiting itself would still require reading through all folders to get modify time to get most recent runs because run folder names do not provide any sorting feature. will work well for thousands of run history.