### PR TITLE
add tasks loaded logs number

### DIFF
--- a/pipelines/api/utils.py
+++ b/pipelines/api/utils.py
@@ -78,8 +78,11 @@ def _slugify_file(filename):
     return basename.rsplit('.', 1)[0]
 
 
-def _run_id_iterator(slug):
-    for sub_folder in os.listdir(slug):
+def _run_id_iterator(slug, log_limits):
+    dir_list = os.listdir(slug)
+    #sorted by modify time
+    dir_list = sorted(dir_list,key=lambda x: os.path.getmtime(os.path.join(slug, x)), reverse = True)
+    for sub_folder in dir_list[:log_limits]:
         if _is_valid_uuid(sub_folder):
             yield sub_folder
 

--- a/pipelines/cli.py
+++ b/pipelines/cli.py
@@ -2,7 +2,7 @@
 '''
 Usage:
     pipelines (--version|--help)
-    pipelines server --workspace=<workspace> [--title=<title>] [--cookie-secret=<cookie-secret>] [--host=<host>] [--port=<port>] [--username=<username>] [--password=<password>] [--ask-password] [--github-auth=<Org/Team>] [--debug]
+    pipelines server --workspace=<workspace> [--title=<title>] [--cookie-secret=<cookie-secret>] [--host=<host>] [--port=<port>] [--username=<username>] [--password=<password>] [--ask-password] [--github-auth=<Org/Team>] [--log-limits=<number>] [--debug]
 
 Options:
     --host=<host>                       Bind address [default: 127.0.0.1]
@@ -14,6 +14,7 @@ Options:
     --github-auth=<Org/Team>            Enable Github Authentication (OAuth). Allow specific Team.
     --workspace=<workspace>             Location of the pipelines and runs [default: /var/lib/pipelines/workspace]
     --title=<title>                     Title on tab
+    --log-limits=<a number>             The number of loaded tasks log 
     --debug                             Set log level to debug
 
 Help:
@@ -33,6 +34,13 @@ from pipelines.api import server
 from pipelines.pipeline.utils import random_secret
 
 MIN_PASSWORD_LEN = 12
+
+def _get_log_limits(args):
+    if args['--log-limits']:
+        return args['--log-limits']
+    if 'LOG_LIMITS' in os.environ:
+        return os.environ['LOG_LIMITS']
+    return None
 
 def _get_username(args):
     if args['--username']:
@@ -78,13 +86,17 @@ def main():
             'workspace': os.path.realpath(os.path.expanduser(args.get('--workspace'))),
             'title': _get_title(args),
             'host': args.get('--host'),
-            'port': args.get('--port')
+            'port': args.get('--port'),
+            'log_limits': _get_log_limits(args)
         }
-
         username = _get_username(args)
         password = _get_password(args)
         cookie_secret = _get_cookie_secret(args)
         ghauth = args.get('--github-auth')
+
+        #set log_limits default value as 20 ,user if not pass this parameter
+        if not options.get('log_limits'):
+            options['log_limits'] = 20
 
         options['cookie_secret']  = cookie_secret if cookie_secret else random_secret()
 


### PR DESCRIPTION
usage:
1.install and test on local ``` pip install git+https://github.com/Wiredcraft/pipelines@add-log-limits```
2.```pipelines server --workspace ~/pipelines_workspace --username admin --password xxxx --log-limits 5```
3.if not pass this parameter, the default log limit number is 20
